### PR TITLE
Add ChatHook framework

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ COPY . .
 
 RUN ./scripts/setup.sh
 
-CMD ["python3", "src/main.py"]
+CMD ["python3", "-u", "src/main.py"]

--- a/src/cogs/quadchat.py
+++ b/src/cogs/quadchat.py
@@ -1,11 +1,17 @@
+import logging
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Literal, Union
+import typing
 import discord
+from discord.app_commands import describe
 from discord.ext import commands
 from quadbot import QuadBot
 import re
 
-ANTI_SNAKE_TEMPLATE = (
+discord.utils.setup_logging(level=logging.DEBUG)
+
+_ANTI_SNAKE_EMBED_TEMPLATE = (
 """
 **Before**: 
 {before}
@@ -16,8 +22,9 @@ ANTI_SNAKE_TEMPLATE = (
 
 
 @dataclass(kw_only=True)
-class Hook:
+class ChatHook:
     pattern: str 
+    target: discord.Member | discord.User | Literal["global"] = "global"
     modifier: Callable[..., bool] = lambda: True 
     enabled: bool = True
 
@@ -25,8 +32,19 @@ class Hook:
         ...
 
 
+    def __str__(self) -> str:
+        return '\n'.join([f"{key.title}: {value}" for key, value in vars(self)])
+
+
+    def embed_field(self, embed: discord.Embed) -> discord.Embed:
+        return embed.add_field(
+            name=f"{self.__class__.__name__}",
+            value=str(self),
+        )
+
+
 @dataclass(kw_only=True)
-class ReplyHook(Hook):
+class ReplyHook(ChatHook):
     response: str
 
     async def trigger(self, msg: discord.Message) -> None:
@@ -34,8 +52,8 @@ class ReplyHook(Hook):
 
 
 @dataclass(kw_only=True)
-class ReactHook(Hook):
-    response: str | discord.Emoji
+class ReactHook(ChatHook):
+    response: discord.Emoji | str
 
     async def trigger(self, msg: discord.Message) -> None:
         await msg.add_reaction(self.response)
@@ -47,44 +65,130 @@ HOOKS = [
 ]
 
 
-class QuadReact(commands.Cog):
-    def __init__(self, bot: QuadBot) -> None:
-        self.bot = bot
-        self._init_hooks()
-
-
-    def _init_hooks(self) -> None:
-        self.hooks = {hook.pattern: hook for hook in HOOKS}
-        self.hook_pattern = re.compile('|'.join(trigger for trigger in self.hooks.keys()))
-
-
-    @commands.command()
-    async def add_react(self, 
-                        ctx: commands.Context,
-                        pattern: str) -> None:
+class HookManager:
+    def __init__(self, chathooks: list[ChatHook] = []) -> None:
         ...
 
 
+class AddCHFlags(commands.FlagConverter):
+    type_: Literal["reply", "reaction"] = (
+        commands.flag(name="type", 
+                      description="The type of ChatHook to add [reply | reaction]")
+    )
+    pattern: str = (
+        commands.flag(description="The pattern to search for.")
+    )
+    response: Union[discord.Emoji, str] = (
+        commands.flag(description="The sentence or emoji that QuadBot should react with")
+    )
+    target: Union[discord.Member, discord.User, Literal["global"]] = (
+        commands.flag(description="The user to match for or \"global\" to match everyone")
+    )
+    use_regex: bool = (
+        commands.flag(name="regex", 
+                      description="Whether or not the pattern uses regular expressions",
+                      default=False)
+    )
+    
+
+class QuadReact(commands.Cog):
+    def __init__(self, bot: QuadBot) -> None:
+        self.bot = bot
+        self._init_chathooks()
+
+
+    def _init_chathooks(self) -> None:
+        self.chathooks: dict[str, ChatHook] = {chathook.pattern: chathook for chathook in HOOKS}
+        self.compiled_patterns: list[re.Pattern] = [re.compile(key) for key in self.chathooks.keys()]
+
+
+    def add_chathook_pattern(self, chathook: ChatHook) -> None:
+        self.compiled_patterns.append(re.compile(chathook.pattern))
+        self.chathooks.update({chathook.pattern: chathook})
+            
+
+    # TODO: add command specific error handling
+    # FIXME: I don't know why but the flag converter doesn't display the descriptions 
+    #        inside the help message for the command
+    @commands.command()
+    async def add_hook(self, ctx: commands.Context, *, flags: AddCHFlags) -> None:
+        print(f"Flags: {flags}")
+        if not flags.use_regex:
+            flags.pattern = re.escape(flags.pattern)
+
+        try: 
+            re.compile(flags.pattern)
+        except re.error as err:
+            await ctx.reply(f"Invalid regex: {err}")
+            return
+
+        match flags.type_:
+            case "reply":
+                flags.response = typing.cast(str, flags.response)
+                chathook = ReplyHook(pattern=flags.pattern, 
+                                     response=flags.response,
+                                     target=flags.target)
+
+            case "reaction":
+                flags.response = typing.cast(discord.Emoji, flags.response)
+                chathook = ReactHook(pattern=flags.pattern,
+                                     response=flags.response,
+                                     target=flags.target)
+        self.add_chathook_pattern(chathook)
+        await ctx.reply("ChatHook added successfully")
+
+
+    @add_hook.error
+    async def add_hook_error(self, ctx: commands.Context, error: commands.CommandError) -> None:
+        print(error)
+
+
     @commands.Cog.listener()
-    async def on_hook_trigger(self, msg: discord.Message, hook: Hook) -> None:
-        if not hook.enabled or not hook.modifier():
-            print(f"Hook {hook} failed modifier check or is not enabled!")
+    async def on_chathook_trigger(self, msg: discord.Message, chathook: ChatHook) -> None:
+        if not chathook.enabled:
+            print(f"ChatHook {chathook} is not enabled!")
             return 
 
-        await hook.trigger(msg)
+        if chathook.target != "global" and str(msg.author) != str(chathook.target):
+            print(f"Message author doesn't match ChatHook target: {chathook.target}")
+            return 
+
+        if not chathook.modifier():
+            print(f"ChatHook {chathook} failed modifier check!")
+            return 
+
+        await chathook.trigger(msg)
 
 
     @commands.Cog.listener()
     async def on_message(self, msg: discord.Message) -> None:
-        print(f"Got message: {msg.content}")
-        if msg.author.bot: # gtfo if user is a bot
+        if msg.author.bot: # don't search if user is a bot
             return
 
-        if (matches := self.hook_pattern.findall(msg.content)):
-            print(f"Found matches for hooks: {matches}")
-            for match in matches:
-                print(f"Dispatching hook for {match}")
-                self.bot.dispatch("hook_trigger", msg, self.hooks[match])
+        prefix = tuple(await self.bot.get_prefix(msg))
+        if msg.content.startswith(prefix): # don't search if this is a command
+            return
+
+        print(f"Scanning for patterns: {self.compiled_patterns}")
+        for pattern in self.compiled_patterns:
+            match = pattern.match(msg.content)
+            
+            if match:
+                print(f"Dispatching ChatHook for {match}")
+                self.bot.dispatch("chathook_trigger", msg, self.chathooks[match.re.pattern])
+
+
+    @commands.Cog.listener()
+    async def on_command_error(self, ctx: commands.Context, err: commands.CommandError) -> None:
+        if isinstance(err, commands.CommandNotFound):
+            print(f"{err}: Unknown command.")
+            await ctx.reply(self.bot.get_error_msg())
+
+    
+    @commands.Cog.listener()
+    async def on_ready(self) -> None:
+        print("Loaded QuadReact cog!")
+
 
 
 class QuadChat(commands.Cog):
@@ -118,14 +222,14 @@ class QuadChat(commands.Cog):
         if self.edited_msg is None:
             await ctx.reply("No recently edited messages :sob:")
             return
-    
+
         embed = discord.Embed(
             title=":x: :snake: Antisnake! :x: :snake:",
-            description=ANTI_SNAKE_TEMPLATE.format(**self.edited_msg)
+            description=_ANTI_SNAKE_EMBED_TEMPLATE.format(**self.edited_msg)
         )
         await ctx.reply(embed=embed)
 
-        
+
     @commands.Cog.listener()
     async def on_message(self, ctx: commands.Context) -> None:
         if ctx.author.bot:
@@ -140,7 +244,7 @@ class QuadChat(commands.Cog):
 
 
     @commands.Cog.listener()
-    async def on_cog_command_error(self, ctx: commands.Context, err: commands.CommandError) -> None:
+    async def on_command_error(self, ctx: commands.Context, err: commands.CommandError) -> None:
         if isinstance(err, commands.CommandNotFound):
             print(f"{err}: Unknown command.")
             await ctx.reply(self.bot.get_error_msg())

--- a/src/cogs/quadchat.py
+++ b/src/cogs/quadchat.py
@@ -70,12 +70,6 @@ class EventHook(ChatHook):
         self.bot.dispatch(self.event_name, msg)
 
 
-DEFAULT_HOOKS = [
-    ReplyHook(pattern="balls", response="balls"),
-    ReactHook(pattern="skull", response=chr(0x1f480)),
-]
-
-
 class AddCHFlags(commands.FlagConverter):
     type_: Literal["reply", "reaction"] = (
         commands.flag(name="type", 
@@ -104,7 +98,13 @@ class QuadReact(commands.Cog):
 
 
     def _init_chathooks(self) -> None:
-        self.chathooks: dict[str, ChatHook] = {chathook.pattern: chathook for chathook in DEFAULT_HOOKS}
+        default_hooks = [
+            ReplyHook(pattern="balls", response="balls"),
+            ReactHook(pattern="skull", response=chr(0x1f480)),
+            EventHook(pattern=r"\w+\+\+|<@!?\d+> \+\+", event_name="elo_increment", bot=self.bot),
+            EventHook(pattern=r"\w+\-\-|<@!?\d+> \-\-", event_name="elo_decrement", bot=self.bot),
+        ]
+        self.chathooks: dict[str, ChatHook] = {chathook.pattern: chathook for chathook in default_hooks}
         self.compiled_patterns: list[re.Pattern] = [re.compile(key) for key in self.chathooks.keys()]
 
 
@@ -235,6 +235,16 @@ class QuadChat(commands.Cog):
             description=_ANTI_SNAKE_EMBED_TEMPLATE.format(**self.edited_msg)
         )
         await ctx.reply(embed=embed)
+
+
+    @commands.Cog.listener()
+    async def on_elo_increment(self, msg: discord.Message) -> None:
+        print("++")
+
+
+    @commands.Cog.listener()
+    async def on_elo_decrement(self, msg: discord.Message) -> None:
+        print("--")
 
 
     @commands.Cog.listener()

--- a/src/cogs/quadchat.py
+++ b/src/cogs/quadchat.py
@@ -59,7 +59,7 @@ class ReactHook(ChatHook):
         await msg.add_reaction(self.response)
 
 
-HOOKS = [
+DEFAULT_HOOKS = [
     ReplyHook(pattern="balls", response="balls"),
     ReactHook(pattern="skull", response=chr(0x1f480)),
 ]
@@ -98,7 +98,7 @@ class QuadReact(commands.Cog):
 
 
     def _init_chathooks(self) -> None:
-        self.chathooks: dict[str, ChatHook] = {chathook.pattern: chathook for chathook in HOOKS}
+        self.chathooks: dict[str, ChatHook] = {chathook.pattern: chathook for chathook in DEFAULT_HOOKS}
         self.compiled_patterns: list[re.Pattern] = [re.compile(key) for key in self.chathooks.keys()]
 
 

--- a/src/cogs/quadchat.py
+++ b/src/cogs/quadchat.py
@@ -59,8 +59,6 @@ class ReactHook(ChatHook):
         await msg.add_reaction(self.response)
 
 
-# TODO: Figure out how to make this work. Since these aren't supposed to be added by users,
-#       I could just add a custom event? 
 @dataclass(kw_only=True)
 class EventHook(ChatHook):
     event_name: str
@@ -99,10 +97,24 @@ class QuadReact(commands.Cog):
 
     def _init_chathooks(self) -> None:
         default_hooks = [
-            ReplyHook(pattern="balls", response="balls"),
-            ReactHook(pattern="skull", response=chr(0x1f480)),
-            EventHook(pattern=r"\w+\+\+|<@!?\d+> \+\+", event_name="elo_increment", bot=self.bot),
-            EventHook(pattern=r"\w+\-\-|<@!?\d+> \-\-", event_name="elo_decrement", bot=self.bot),
+            ReplyHook(
+                pattern="balls", 
+                response="balls"
+            ),
+            ReactHook(
+                pattern="skull", 
+                response=chr(0x1f480)
+            ),
+            EventHook(
+                pattern=r"\w+\+\+|<@!?\d+> \+\+", # Matches for a name or mention followed by ++
+                event_name="elo_increment", 
+                bot=self.bot
+            ),
+            EventHook(
+                pattern=r"\w+\-\-|<@!?\d+> \-\-", # Matches for a name or mention followed by --
+                event_name="elo_decrement", 
+                bot=self.bot
+            ),
         ]
         self.chathooks: dict[str, ChatHook] = {chathook.pattern: chathook for chathook in default_hooks}
         self.compiled_patterns: list[re.Pattern] = [re.compile(key) for key in self.chathooks.keys()]
@@ -237,13 +249,17 @@ class QuadChat(commands.Cog):
         await ctx.reply(embed=embed)
 
 
+    # TODO: Hook this up to ELO system once DB is hooked up
     @commands.Cog.listener()
     async def on_elo_increment(self, msg: discord.Message) -> None:
+        # Is there a sane way for me to pass in the name of the target without rescanning?
         print("++")
 
 
+    # TODO: Hook this up to ELO system once DB is hooked up
     @commands.Cog.listener()
     async def on_elo_decrement(self, msg: discord.Message) -> None:
+        # Is there a sane way for me to pass in the name of the target without rescanning?
         print("--")
 
 

--- a/src/cogs/quadchat.py
+++ b/src/cogs/quadchat.py
@@ -69,6 +69,9 @@ class EventHook(ChatHook):
 
 
 class AddCHFlags(commands.FlagConverter):
+    """
+    blah
+    """
     type_: Literal["reply", "reaction"] = (
         commands.flag(name="type", 
                       description="The type of ChatHook to add [reply | reaction]")
@@ -125,7 +128,6 @@ class QuadReact(commands.Cog):
         self.chathooks.update({chathook.pattern: chathook})
             
 
-    # TODO: add command specific error handling
     # FIXME: I don't know why but the flag converter doesn't display the descriptions 
     #        inside the help message for the command
     @commands.command()
@@ -138,6 +140,10 @@ class QuadReact(commands.Cog):
             re.compile(flags.pattern)
         except re.error as err:
             await ctx.reply(f"Invalid regex: {err}")
+            return
+
+        if flags.target != "global" and flags.target.bot:
+            await ctx.reply(f"Cannot use a bot as the target for a ChatHook")
             return
 
         match flags.type_:
@@ -157,6 +163,7 @@ class QuadReact(commands.Cog):
         await ctx.reply("ChatHook added successfully")
 
 
+    # TODO: add command specific error handling
     @add_hook.error
     async def add_hook_error(self, ctx: commands.Context, error: commands.CommandError) -> None:
         print(error)
@@ -197,13 +204,6 @@ class QuadReact(commands.Cog):
                 self.bot.dispatch("chathook_trigger", msg, self.chathooks[match.re.pattern])
 
 
-    @commands.Cog.listener()
-    async def on_command_error(self, ctx: commands.Context, err: commands.CommandError) -> None:
-        if isinstance(err, commands.CommandNotFound):
-            print(f"{err}: Unknown command.")
-            await ctx.reply(self.bot.get_error_msg())
-
-    
     @commands.Cog.listener()
     async def on_ready(self) -> None:
         print("Loaded QuadReact cog!")

--- a/src/cogs/quadchat.py
+++ b/src/cogs/quadchat.py
@@ -59,15 +59,21 @@ class ReactHook(ChatHook):
         await msg.add_reaction(self.response)
 
 
+# TODO: Figure out how to make this work. Since these aren't supposed to be added by users,
+#       I could just add a custom event? 
+@dataclass(kw_only=True)
+class EventHook(ChatHook):
+    event_name: str
+    bot: commands.Bot
+
+    async def trigger(self, msg: discord.Message) -> None:
+        self.bot.dispatch(self.event_name, msg)
+
+
 DEFAULT_HOOKS = [
     ReplyHook(pattern="balls", response="balls"),
     ReactHook(pattern="skull", response=chr(0x1f480)),
 ]
-
-
-class HookManager:
-    def __init__(self, chathooks: list[ChatHook] = []) -> None:
-        ...
 
 
 class AddCHFlags(commands.FlagConverter):
@@ -134,6 +140,7 @@ class QuadReact(commands.Cog):
                 chathook = ReactHook(pattern=flags.pattern,
                                      response=flags.response,
                                      target=flags.target)
+
         self.add_chathook_pattern(chathook)
         await ctx.reply("ChatHook added successfully")
 

--- a/src/cogs/quadchat.py
+++ b/src/cogs/quadchat.py
@@ -1,7 +1,6 @@
 from collections.abc import Callable
 from enum import Enum
-from dataclasses import dataclass, field
-from typing import Any
+from dataclasses import dataclass
 import discord
 from discord.ext import commands
 from quadbot import QuadBot
@@ -47,19 +46,15 @@ class QuadReact(commands.Cog):
 
     @commands.Cog.listener()
     async def on_hook_trigger(self, msg: discord.Message, hook: ReactHook) -> None:
-        print("hook reached")
         if not hook.enabled or not hook.modifier():
             print(f"Hook {hook} failed modifier check or is not enabled!")
             return 
 
         if isinstance(hook.response, str):
-            print("Hook is a str type")
             await msg.reply(hook.response)
         elif isinstance(hook.response, discord.Emoji):
-            print("Hook is an Emoji type")
             await msg.add_reaction(hook.response)
         else:
-            print("Hook is a callable")
             hook.response()
 
 

--- a/src/cogs/quaddev.py
+++ b/src/cogs/quaddev.py
@@ -50,7 +50,7 @@ class QuadDev(commands.Cog):
         #       instead of being hard-coded in. This has already caused issues once.
         for filename in os.listdir("./src/cogs"):
             if filename.endswith(".py"):
-                print(f"Reloading cog: {filename}")
+                print(f"Reloading extension: {filename}")
                 await self.bot.reload_extension(f"cogs.{filename[:-3]}")
 
 

--- a/src/cogs/quaddev.py
+++ b/src/cogs/quaddev.py
@@ -1,10 +1,9 @@
 import os
-import logging
 import discord
 from discord.ext import commands
 
 # TODO: Setup logger
-discord.utils.setup_logging(level=logging.DEBUG)
+discord.utils.setup_logging()
 
 COG_STATS_TEMPLATE = (
 """
@@ -47,10 +46,12 @@ class QuadDev(commands.Cog):
         """
         [Admin only] Reload all cogs.
         """
-        for filename in os.listdir("./cogs"):
+        # TODO: This should set to some variable (maybe from the bot instance) 
+        #       instead of being hard-coded in. This has already caused issues once.
+        for filename in os.listdir("./src/cogs"):
             if filename.endswith(".py"):
                 print(f"Reloading cog: {filename}")
-                await self.bot.reload_extension("cogs.{filename[:-3]}")
+                await self.bot.reload_extension(f"cogs.{filename[:-3]}")
 
 
     @commands.command()

--- a/src/cogs/quaddev.py
+++ b/src/cogs/quaddev.py
@@ -1,7 +1,39 @@
 import os
+import logging
+import discord
 from discord.ext import commands
 
 # TODO: Setup logger
+discord.utils.setup_logging(level=logging.DEBUG)
+
+COG_STATS_TEMPLATE = (
+"""
+**App Commands**:
+{app_cmds}
+**Commands**:
+{cmds}
+**Listeners**:
+{listeners}
+""".strip())
+
+def format_cog_list(bot: commands.Bot) -> discord.Embed:
+    cogs = '\n'.join([cog for cog in bot.cogs.keys()])
+    return discord.Embed(
+        title="Currently loaded Cogs:",
+        description=cogs
+    )
+
+
+def format_cog_stats(cog: commands.Cog) -> discord.Embed:
+    stats = {
+        "app_cmds": '\n'.join([str(app_cmd) for app_cmd in cog.walk_app_commands()]),
+        "cmds": '\n'.join([str(cmd) for cmd in cog.walk_commands()]),
+        "listeners": '\n'.join([str(listener) for listener in cog.get_listeners()]),
+    }
+    return discord.Embed(
+        title=f"Cog: {cog.qualified_name}",
+        description=COG_STATS_TEMPLATE.format(**stats)
+    )
 
 
 class QuadDev(commands.Cog):
@@ -11,7 +43,7 @@ class QuadDev(commands.Cog):
 
     @commands.command()
     @commands.is_owner()
-    async def reload_all(self, ctx: commands.Context) -> None:
+    async def reload_all(self, _: commands.Context) -> None:
         """
         [Admin only] Reload all cogs.
         """
@@ -34,10 +66,43 @@ class QuadDev(commands.Cog):
             print(f"Synced command {cmd}")
 
 
+    @commands.command()
+    @commands.is_owner()
+    async def inspect(self, 
+                      ctx: commands.Context, 
+                      cog_name: str) -> None:
+        """
+        [Admin only] Give a detailed look at a specific Cog
+        """
+        cog = self.bot.get_cog(cog_name)
+
+        if cog is None:
+            await ctx.reply(f"Unable to find cog: {cog_name}")
+            return
+
+        embed = format_cog_stats(cog)
+        await ctx.reply(embed=embed)
+
+
+    @commands.command()
+    @commands.is_owner()
+    async def show_cogs(self, ctx: commands.Context) -> None:
+        """
+        [Admin only] Return a list of the Bot's currently loaded cogs
+        """
+        embed = format_cog_list(self.bot)
+        await ctx.reply(embed=embed)
+
+
+    @commands.Cog.listener()
+    async def on_cog_command_error(self, ctx: commands.Context, err: commands.CommandError) -> None:
+        await ctx.reply(f"Error: {err}")
+
+
     @commands.Cog.listener()
     async def on_ready(self) -> None:
         print("Loaded QuadDev cog!")
 
 
 async def setup(bot: commands.Bot) -> None:
-    await bot.add_cog(QuadDev(bot))
+    await bot.add_cog(QuadDev(bot), override=True)


### PR DESCRIPTION
### Description
This PR implements the ChatHook framework allowing the bot to dynamically reply, react, or trigger events whenever it matches a Regex pattern.

### Features:
- ReplyHooks, where QuadBot will reply to a message featuring a matched pattern
- ReactHooks, where QuadBot will react to a message featuring a matched pattern
- EventHooks, where QuadBot will trigger an bot event when a pattern is matched (This has the most potential)
- add_hook user command
- show_hooks user command

### Fixes
- #13 fixed by 5c88d3eea106e733fa58cef69196d9a30251d4d8

### Missing:
In the interest of making forward progress on the bot, I've decided that it's acceptable for the time being to submit this PR in a mostly finished state. However, I do intend getting to the following at some point:
- Refactoring. I'm not super happy with the readability and design of some of the code. This can definitely be improved.
- Slash command support and interaction support. Due to the complexity of these user commands, it would be extremely beneficial to integrate some kind of GUI support to help the usability. 
- Full command and argument descriptions. 
- Disable and remove hook commands.
