### PR TITLE
feat(quadchat): add say command for puppeting the bot

### DIFF
--- a/src/cogs/quadchat.py
+++ b/src/cogs/quadchat.py
@@ -257,6 +257,25 @@ class QuadChat(commands.Cog):
         self.deleted_msgs: dict[int, tuple[discord.Message, datetime]] = {}
 
 
+    @commands.command(
+            name = "say",
+            description = "Puppet me and make me say despicable things. You sick fuck.",
+            )
+    async def say(self,
+                  ctx: commands.Context,
+                  *,
+                  arg: typing.Optional[str] = commands.parameter(
+                      default="*QuadBot stares blankly*",
+                      description="Your incredibly offensive message")
+                  ) -> None:
+        try:
+            await ctx.message.delete()
+        except Exception as e:
+            ctx.reply(f"I don't have proper perms to delete your message. Get leaked, dumbass.")
+            print(f"Exception: {e}")
+        await ctx.send(arg)
+
+
     @commands.command()
     async def stats(self, 
                     ctx: commands.Context, 


### PR DESCRIPTION
per request from @Aerothieus, I ported over the say command from kbot. Its code is more or less identical except this one can take a variable number of arguments without needing to be wrapped in quotes. Works well from my brief 2 minutes of testing.